### PR TITLE
Track the total connection count.

### DIFF
--- a/SCRIPTING
+++ b/SCRIPTING
@@ -106,6 +106,7 @@ Done
   summary = {
     duration = N,  -- run duration in microseconds
     requests = N,  -- total completed requests
+    connects = N,  -- total connection attempts
     bytes    = N,  -- total bytes received
     errors   = {
       connect = N, -- total socket connection errors

--- a/src/script.c
+++ b/src/script.c
@@ -209,10 +209,11 @@ void script_header_done(lua_State *L, luaL_Buffer *buffer) {
     luaL_pushresult(buffer);
 }
 
-void script_summary(lua_State *L, uint64_t duration, uint64_t requests, uint64_t bytes) {
+void script_summary(lua_State *L, uint64_t duration, uint64_t requests, uint64_t bytes, uint64_t connects) {
     const table_field fields[] = {
         { "duration", LUA_TNUMBER, &duration },
         { "requests", LUA_TNUMBER, &requests },
+        { "connects", LUA_TNUMBER, &connects },
         { "bytes",    LUA_TNUMBER, &bytes    },
         { NULL,       0,           NULL      },
     };

--- a/src/script.h
+++ b/src/script.h
@@ -25,7 +25,7 @@ bool script_is_static(lua_State *);
 bool script_want_response(lua_State *L);
 bool script_has_delay(lua_State *L);
 bool script_has_done(lua_State *L);
-void script_summary(lua_State *, uint64_t, uint64_t, uint64_t);
+void script_summary(lua_State *, uint64_t, uint64_t, uint64_t, uint64_t);
 void script_errors(lua_State *, errors *);
 
 void script_copy_value(lua_State *, lua_State *, int);

--- a/src/wrk.h
+++ b/src/wrk.h
@@ -31,6 +31,7 @@ typedef struct {
     uint64_t connections;
     uint64_t complete;
     uint64_t requests;
+    uint64_t connects;
     uint64_t bytes;
     uint64_t start;
     lua_State *L;


### PR DESCRIPTION
Track the total connection count across the worker threads. This
makes it more obvious when connection keepalive is being used.